### PR TITLE
Graphql Service

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,1 +1,8 @@
 PORT=8080
+GENRES_BASE_URL='http://localhost:3001/v1/'
+ARTISTS_BASE_URL='http://localhost:3002/v1/'
+BANDS_BASE_URL='http://localhost:3003/v1/'
+USERS_BASE_URL='http://localhost:3004/v1/'
+ALBUMS_BASE_URL='http://localhost:3005/v1/'
+TRACKS_BASE_URL='http://localhost:3006/v1/'
+FAVOURITES_BASE_URL='http://localhost:3007/v1/'

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Clone repository [here](https://github.com/rolling-scopes-school/node-graphql-se
 
 * App served @ `http://localhost:8080` without nodemon
 ---
-After start, go to address wrote in console
+After start, go to address wrote in console  
 
 Now you can make requests, using appollo studio, just by clicking which resource and fields you want
 ---

--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# RSSchool NodeJS graphql-service
+> Task [here](https://github.com/AlreadyBored/nodejs-assignments/blob/main/assignments/graphql-service/assignment.md)
+
+## Installation
+1. Clone/download repo
+2. `npm install`
+
+## Usage
+
+### Get repository with microservices
+Clone repository [here](https://github.com/rolling-scopes-school/node-graphql-service) and follow instructions
+
+### Set Port:
+  >rename .env-example to .env that use port parametеr and default paths for mircroservices
+
+**Development**
+
+`npm run start:dev`
+
+* App served @ `http://localhost:8080` with nodemon
+
+**Production**
+
+`npm run start`
+
+* App served @ `http://localhost:8080` without nodemon
+---
+After start, go to address wrote in console
+
+Now you can make requests, using appollo studio, just by clicking which resource and fields you want
+---
+
+**Note**: replace `npm` with `yarn` in `package.json` if you use yarn.

--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,28 @@
+import { ApolloServer, gql, } from 'apollo-server';
+import { GenreService } from './src/modules/genres/services/genre.service';
+import { genreType } from './src/modules/genres/schemas/genre';
+import { resolvers } from './src/modules/genres/resolvers/genre.resolver';
+import { makeExecutableSchema } from '@graphql-tools/schema';
+import 'dotenv/config';
+
+const PORT = process.env.PORT || 8080;
+
+const genres = makeExecutableSchema({
+  typeDefs: genreType,
+  resolvers
+});
+
+const server = new ApolloServer({
+  schema: genres,
+  csrfPrevention: true,
+  cache: 'bounded',
+  dataSources: () => {
+    return {
+      Genre: new GenreService(),
+    };
+  }
+});
+
+server.listen({ port: PORT }).then(({ url }) => {
+  console.log(`🚀  Server ready at ${url}`);
+});

--- a/index.ts
+++ b/index.ts
@@ -20,6 +20,7 @@ const server = new ApolloServer({
   schema: genres,
   csrfPrevention: true,
   cache: 'bounded',
+  context: ({ req }) => ({ token: req.headers.authorization || '' }),
   dataSources: () => {
     return {
       Genre: new GenreService(),

--- a/index.ts
+++ b/index.ts
@@ -1,13 +1,13 @@
 import { ApolloServer } from 'apollo-server';
-import { genreType, genresResolvers, GenreService } from './src/modules';
+import { genreType, genresResolvers, GenreService, artistType, artistsResolvers, ArtistService, bandType, memberType } from './src/modules';
 import { makeExecutableSchema } from '@graphql-tools/schema';
 import 'dotenv/config';
 
 const PORT = process.env.PORT || 8080;
 
 const genres = makeExecutableSchema({
-  typeDefs: genreType,
-  resolvers: genresResolvers
+  typeDefs: [genreType, artistType, bandType, memberType],
+  resolvers: [genresResolvers, artistsResolvers]
 });
 
 const server = new ApolloServer({
@@ -17,6 +17,7 @@ const server = new ApolloServer({
   dataSources: () => {
     return {
       Genre: new GenreService(),
+      Artist: new ArtistService(),
     };
   }
 });

--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,9 @@
 import { ApolloServer } from 'apollo-server';
-import { genreType, genresResolvers, GenreService, artistType, artistsResolvers, ArtistService, bandType, memberType } from './src/modules';
+import {
+  genreType, genresResolvers, GenreService,
+  artistType, artistsResolvers, ArtistService,
+  bandType, memberType, bandsResolvers, BandService
+} from './src/modules';
 import { makeExecutableSchema } from '@graphql-tools/schema';
 import 'dotenv/config';
 
@@ -7,7 +11,7 @@ const PORT = process.env.PORT || 8080;
 
 const genres = makeExecutableSchema({
   typeDefs: [genreType, artistType, bandType, memberType],
-  resolvers: [genresResolvers, artistsResolvers]
+  resolvers: [genresResolvers, artistsResolvers, bandsResolvers]
 });
 
 const server = new ApolloServer({
@@ -18,6 +22,7 @@ const server = new ApolloServer({
     return {
       Genre: new GenreService(),
       Artist: new ArtistService(),
+      Band: new BandService(),
     };
   }
 });

--- a/index.ts
+++ b/index.ts
@@ -1,7 +1,5 @@
-import { ApolloServer, gql, } from 'apollo-server';
-import { GenreService } from './src/modules/genres/services/genre.service';
-import { genreType } from './src/modules/genres/schemas/genre.schema';
-import { resolvers } from './src/modules/genres/resolvers/genre.resolver';
+import { ApolloServer } from 'apollo-server';
+import { genreType, genresResolvers, GenreService } from './src/modules';
 import { makeExecutableSchema } from '@graphql-tools/schema';
 import 'dotenv/config';
 
@@ -9,7 +7,7 @@ const PORT = process.env.PORT || 8080;
 
 const genres = makeExecutableSchema({
   typeDefs: genreType,
-  resolvers
+  resolvers: genresResolvers
 });
 
 const server = new ApolloServer({

--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,6 @@
 import { ApolloServer, gql, } from 'apollo-server';
 import { GenreService } from './src/modules/genres/services/genre.service';
-import { genreType } from './src/modules/genres/schemas/genre';
+import { genreType } from './src/modules/genres/schemas/genre.schema';
 import { resolvers } from './src/modules/genres/resolvers/genre.resolver';
 import { makeExecutableSchema } from '@graphql-tools/schema';
 import 'dotenv/config';

--- a/index.ts
+++ b/index.ts
@@ -2,7 +2,9 @@ import { ApolloServer } from 'apollo-server';
 import {
   genreType, genresResolvers, GenreService,
   artistType, artistsResolvers, ArtistService,
-  bandType, memberType, bandsResolvers, BandService
+  bandType, memberType, bandsResolvers, BandService,
+  albumType, albumsResolvers, AlbumService,
+  trackType, tracksResolvers, TrackService
 } from './src/modules';
 import { makeExecutableSchema } from '@graphql-tools/schema';
 import 'dotenv/config';
@@ -10,8 +12,8 @@ import 'dotenv/config';
 const PORT = process.env.PORT || 8080;
 
 const genres = makeExecutableSchema({
-  typeDefs: [genreType, artistType, bandType, memberType],
-  resolvers: [genresResolvers, artistsResolvers, bandsResolvers]
+  typeDefs: [genreType, artistType, bandType, memberType, albumType, trackType],
+  resolvers: [genresResolvers, artistsResolvers, bandsResolvers, albumsResolvers, tracksResolvers]
 });
 
 const server = new ApolloServer({
@@ -23,6 +25,8 @@ const server = new ApolloServer({
       Genre: new GenreService(),
       Artist: new ArtistService(),
       Band: new BandService(),
+      Album: new AlbumService(),
+      Track: new TrackService()
     };
   }
 });

--- a/index.ts
+++ b/index.ts
@@ -4,7 +4,7 @@ import {
   artistType, artistsResolvers, ArtistService,
   bandType, memberType, bandsResolvers, BandService,
   albumType, albumsResolvers, AlbumService,
-  trackType, tracksResolvers, TrackService
+  trackType, tracksResolvers, TrackService, userType, usersResolvers, UserService
 } from './src/modules';
 import { makeExecutableSchema } from '@graphql-tools/schema';
 import 'dotenv/config';
@@ -12,8 +12,8 @@ import 'dotenv/config';
 const PORT = process.env.PORT || 8080;
 
 const genres = makeExecutableSchema({
-  typeDefs: [genreType, artistType, bandType, memberType, albumType, trackType],
-  resolvers: [genresResolvers, artistsResolvers, bandsResolvers, albumsResolvers, tracksResolvers]
+  typeDefs: [genreType, artistType, bandType, memberType, albumType, trackType, userType],
+  resolvers: [genresResolvers, artistsResolvers, bandsResolvers, albumsResolvers, tracksResolvers, usersResolvers]
 });
 
 const server = new ApolloServer({
@@ -26,7 +26,8 @@ const server = new ApolloServer({
       Artist: new ArtistService(),
       Band: new BandService(),
       Album: new AlbumService(),
-      Track: new TrackService()
+      Track: new TrackService(),
+      User: new UserService(),
     };
   }
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "apollo-datasource-rest": "^3.6.1",
         "apollo-server": "^3.9.0",
-        "dot-env": "^0.0.1",
+        "dotenv": "^16.0.1",
         "graphql": "^16.5.0"
       },
       "devDependencies": {
@@ -1133,11 +1133,6 @@
         "node": ">=0.3.1"
       }
     },
-    "node_modules/dot-env": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/dot-env/-/dot-env-0.0.1.tgz",
-      "integrity": "sha512-SajHtzm3v7yjMH8DW9xY+4i7Zv/cN3aMtLVy0mRMuZu8L9qRCR7CNqcl4KBbG27e5Up4BpSlEyPXXLNbSAe2DQ=="
-    },
     "node_modules/dot-prop": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
@@ -1148,6 +1143,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz",
+      "integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/duplexer3": {
@@ -3626,11 +3629,6 @@
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
       "dev": true
     },
-    "dot-env": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/dot-env/-/dot-env-0.0.1.tgz",
-      "integrity": "sha512-SajHtzm3v7yjMH8DW9xY+4i7Zv/cN3aMtLVy0mRMuZu8L9qRCR7CNqcl4KBbG27e5Up4BpSlEyPXXLNbSAe2DQ=="
-    },
     "dot-prop": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
@@ -3639,6 +3637,11 @@
       "requires": {
         "is-obj": "^2.0.0"
       }
+    },
+    "dotenv": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz",
+      "integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ=="
     },
     "duplexer3": {
       "version": "0.1.4",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start:dev": "nodemon index.ts"
+    "start:dev": "nodemon index.ts",
+    "start": "tsc && node _build/index.js"
   },
   "keywords": [],
   "author": "",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "apollo-datasource-rest": "^3.6.1",
     "apollo-server": "^3.9.0",
-    "dot-env": "^0.0.1",
+    "dotenv": "^16.0.1",
     "graphql": "^16.5.0"
   },
   "devDependencies": {

--- a/src/modules/albums/resolvers/album.resolver.ts
+++ b/src/modules/albums/resolvers/album.resolver.ts
@@ -31,5 +31,19 @@ export const albumsResolvers = {
       const genres = await dataSources.Genre.getGenres();
       return genres.filter((g: any) => _source.genresIds.includes(g.id));
     }
+  },
+
+  Mutation: {
+    async createAlbum(_source: any, _args: any, { dataSources, token }: any) {
+      return dataSources.Album.createAlbum(_args, token);
+    },
+
+    async deleteAlbum(_source: any, { id }: any, { dataSources, token }: any) {
+      return dataSources.Album.deleteAlbum(id, token);
+    },
+
+    async updateAlbum(_source: any, { id, ..._args }: any, { dataSources, token }: any) {
+      return dataSources.Album.updateAlbum(id, _args, token);
+    }
   }
 };

--- a/src/modules/albums/resolvers/album.resolver.ts
+++ b/src/modules/albums/resolvers/album.resolver.ts
@@ -1,0 +1,35 @@
+export const albumsResolvers = {
+  Query: {
+
+    async albums(_source: any, _args: any, { dataSources }: any) {
+      const { offset, limit } = _args;
+      return dataSources.Album.getAlbums(limit, offset);
+    },
+
+    async album(_source: any, { id }: { id: string; }, { dataSources }: any) {
+      return dataSources.Album.getAlbum(id);
+    }
+  },
+
+  Album: {
+    async artists(_source: any, _args: any, { dataSources }: any) {
+      const artists = await dataSources.Artist.getArtists();
+      return artists.filter((a: any) => _source.artistsIds.includes(a.id));
+    },
+
+    async bands(_source: any, _args: any, { dataSources }: any) {
+      const bands = await dataSources.Band.getBands();
+      return bands.filter((b: any) => _source.bandsIds.includes(b.id));
+    },
+
+    async tracks(_source: any, _args: any, { dataSources }: any) {
+      const tracks = await dataSources.Track.getTracks();
+      return tracks.filter((t: any) => _source.tracksIds.includes(t.id));
+    },
+
+    async genres(_source: any, _args: any, { dataSources }: any) {
+      const genres = await dataSources.Genre.getGenres();
+      return genres.filter((g: any) => _source.genresIds.includes(g.id));
+    }
+  }
+};

--- a/src/modules/albums/schemas/album.schema.ts
+++ b/src/modules/albums/schemas/album.schema.ts
@@ -1,0 +1,16 @@
+export const albumType = `
+type Album {
+    id: ID!
+    name: String
+    released: Int
+    artists: [Artist]
+    bands: [Band]
+    tracks: [Track]
+    genres: [Genre]
+    image: String
+}
+
+type Query {
+    album(id: ID!): Album
+    albums(limit: Int, offset: Int): [Album]
+}`;

--- a/src/modules/albums/schemas/album.schema.ts
+++ b/src/modules/albums/schemas/album.schema.ts
@@ -19,10 +19,10 @@ type Mutation {
     createAlbum(
         name: String
         released: Int
-        artists: [String]
-        bands: [String]
-        tracks: [String]
-        genres: [String]
+        artistsIds: [String]
+        bandsIds: [String]
+        trackIds: [String]
+        genresIds: [String]
         image: String): Album
 
     deleteAlbum(id: ID!): Result
@@ -30,10 +30,10 @@ type Mutation {
         id: ID!,
         name: String
         released: Int
-        artists: [String]
-        bands: [String]
-        tracks: [String]
-        genres: [String]
+        artistsIds: [String]
+        bandsIds: [String]
+        trackIds: [String]
+        genresIds: [String]
         image: String): Album
 }
 

--- a/src/modules/albums/schemas/album.schema.ts
+++ b/src/modules/albums/schemas/album.schema.ts
@@ -13,4 +13,28 @@ type Album {
 type Query {
     album(id: ID!): Album
     albums(limit: Int, offset: Int): [Album]
-}`;
+}
+
+type Mutation {
+    createAlbum(
+        name: String
+        released: Int
+        artists: [String]
+        bands: [String]
+        tracks: [String]
+        genres: [String]
+        image: String): Album
+
+    deleteAlbum(id: ID!): Result
+    updateAlbum(
+        id: ID!,
+        name: String
+        released: Int
+        artists: [String]
+        bands: [String]
+        tracks: [String]
+        genres: [String]
+        image: String): Album
+}
+
+`;

--- a/src/modules/albums/services/album.service.ts
+++ b/src/modules/albums/services/album.service.ts
@@ -1,0 +1,20 @@
+import { RESTDataSource } from 'apollo-datasource-rest';
+
+export class AlbumService extends RESTDataSource {
+  constructor() {
+    super();
+    this.baseURL = process.env.ALBUMS_BASE_URL;
+  }
+
+  async getAlbums(limit: number = 20, offset: number = 0) {
+    const resp = await this.get(`albums?limit=${limit}&offset=${offset}`);
+    resp.items.forEach((i: any) => i.id = i._id);
+    return resp.items;
+  }
+
+  async getAlbum(id: string) {
+    const item = await this.get(`albums/${id}`);
+    item.id = item._id;
+    return item;
+  }
+};

--- a/src/modules/albums/services/album.service.ts
+++ b/src/modules/albums/services/album.service.ts
@@ -17,4 +17,36 @@ export class AlbumService extends RESTDataSource {
     item.id = item._id;
     return item;
   }
+
+  async createAlbum(data: any, token: string) {
+    const album = await this.post(`albums`, data,
+      {
+        headers: {
+          Authorization: `${token}`
+        }
+      });
+    album.id = album._id;
+    return album;
+  }
+
+  async deleteAlbum(id: string, token: string) {
+    const album = await this.delete(`albums/${id}`, undefined,
+      {
+        headers: {
+          Authorization: `${token}`
+        }
+      });
+    return album;
+  }
+
+  async updateAlbum(id: string, data: any, token: string) {
+    const album = await this.put(`albums/${id}`, data,
+      {
+        headers: {
+          Authorization: `${token}`
+        }
+      });
+    album.id = album._id;
+    return album;
+  }
 };

--- a/src/modules/artists/resolvers/artist.resolver.ts
+++ b/src/modules/artists/resolvers/artist.resolver.ts
@@ -1,12 +1,19 @@
 export const artistsResolvers = {
   Query: {
-    artists:
-      async (_source: any, _args: any, { dataSources }: any) => {
-        const { offset, limit } = _args;
-        return dataSources.Artist.getArtists(limit, offset);
-      },
-    artist(_source: any, { id }: { id: string; }, { dataSources }: any) {
+    async artists(_source: any, _args: any, { dataSources }: any) {
+      const { offset, limit } = _args;
+      return dataSources.Artist.getArtists(limit, offset);
+    },
+
+    async artist(_source: any, { id }: { id: string; }, { dataSources }: any) {
       return dataSources.Artist.getArtist(id);
+    }
+  },
+
+  Artist: {
+    async bands(_source: any, _args: any, { dataSources }: any) {
+      const bands = await dataSources.Band.getBands();
+      return bands.filter((b: any) => _source.bands.includes(b.id));
     }
   }
 };

--- a/src/modules/artists/resolvers/artist.resolver.ts
+++ b/src/modules/artists/resolvers/artist.resolver.ts
@@ -15,5 +15,18 @@ export const artistsResolvers = {
       const bands = await dataSources.Band.getBands();
       return bands.filter((b: any) => _source.bands.includes(b.id));
     }
+  },
+  Mutation: {
+    async createArtist(_source: any, _args: any, { dataSources, token }: any) {
+      return dataSources.Artist.createArtist(_args, token);
+    },
+
+    async deleteArtist(_source: any, { id }: any, { dataSources, token }: any) {
+      return dataSources.Artist.deleteArtist(id, token);
+    },
+
+    async updateArtist(_source: any, { id, ..._args }: any, { dataSources, token }: any) {
+      return dataSources.Artist.updateArtist(id, _args, token);
+    }
   }
 };

--- a/src/modules/artists/resolvers/artist.resolver.ts
+++ b/src/modules/artists/resolvers/artist.resolver.ts
@@ -1,0 +1,12 @@
+export const artistsResolvers = {
+  Query: {
+    artists:
+      async (_source: any, _args: any, { dataSources }: any) => {
+        const { offset, limit } = _args;
+        return dataSources.Artist.getArtists(limit, offset);
+      },
+    artist(_source: any, { id }: { id: string; }, { dataSources }: any) {
+      return dataSources.Artist.getArtist(id);
+    }
+  }
+};

--- a/src/modules/artists/schemas/artist.schema.ts
+++ b/src/modules/artists/schemas/artist.schema.ts
@@ -29,7 +29,7 @@ type Mutation {
         birthDate: String
         birthPlace: String
         country: String
-        bands: [String]
+        bandsIds: [String]
         instruments: [String]): Artist
 
     deleteArtist(id: ID!): Result
@@ -41,7 +41,7 @@ type Mutation {
         birthDate: String
         birthPlace: String
         country: String
-        bands: [String]
+        bandsIds: [String]
         instruments: [String]): Artist
 }
 `;

--- a/src/modules/artists/schemas/artist.schema.ts
+++ b/src/modules/artists/schemas/artist.schema.ts
@@ -11,7 +11,37 @@ type Artist {
     instruments: [String]
 }
 
+type Result {
+    acknowledged: Boolean
+    deletedCount: Int
+}
+
 type Query {
     artist(id: ID!): Artist
     artists(limit: Int, offset: Int): [Artist]
-}`;
+}
+
+type Mutation {
+    createArtist(
+        firstName: String
+        secondName: String
+        middleName: String
+        birthDate: String
+        birthPlace: String
+        country: String
+        bands: [String]
+        instruments: [String]): Artist
+
+    deleteArtist(id: ID!): Result
+    updateArtist(
+        id: ID!
+        firstName: String
+        secondName: String
+        middleName: String
+        birthDate: String
+        birthPlace: String
+        country: String
+        bands: [String]
+        instruments: [String]): Artist
+}
+`;

--- a/src/modules/artists/schemas/artist.schema.ts
+++ b/src/modules/artists/schemas/artist.schema.ts
@@ -1,0 +1,17 @@
+export const artistType = `
+type Artist {
+    id: ID!
+    firstName: String
+    secondName: String
+    middleName: String
+    birthDate: String
+    birthPlace: String
+    country: String
+    bands: [Band]
+    instruments: [String]
+}
+
+type Query {
+    artist(id: ID!): Artist
+    artists(limit: Int, offset: Int): [Artist]
+}`;

--- a/src/modules/artists/services/artist.service.ts
+++ b/src/modules/artists/services/artist.service.ts
@@ -16,4 +16,36 @@ export class ArtistService extends RESTDataSource {
     item.id = item._id;
     return item;
   }
+
+  async createArtist(data: any, token: string) {
+    const artist = await this.post(`artists`, data,
+      {
+        headers: {
+          Authorization: `${token}`
+        }
+      });
+    artist.id = artist._id;
+    return artist;
+  }
+
+  async deleteArtist(id: string, token: string) {
+    const result = await this.delete(`artists/${id}`, undefined,
+      {
+        headers: {
+          Authorization: `${token}`
+        }
+      });
+    return result;
+  }
+
+  async updateArtist(id: string, data: any, token: string) {
+    const artist = await this.put(`artists/${id}`, data,
+      {
+        headers: {
+          Authorization: `${token}`
+        }
+      });
+    artist.id = artist._id;
+    return artist;
+  }
 };

--- a/src/modules/artists/services/artist.service.ts
+++ b/src/modules/artists/services/artist.service.ts
@@ -1,0 +1,19 @@
+import { RESTDataSource } from 'apollo-datasource-rest';
+
+export class ArtistService extends RESTDataSource {
+  constructor() {
+    super();
+    this.baseURL = process.env.ARTISTS_BASE_URL;
+  }
+
+  async getArtists(limit: number = 20, offset: number = 0) {
+    const resp = await this.get(`artists?limit=${limit}&offset=${offset}`);
+    resp.items.forEach((i: any) => i.id = i._id);
+    return resp.items;
+  }
+  async getArtist(id: string) {
+    const item = await this.get(`artists/${id}`);
+    item.id = item._id;
+    return item;
+  }
+};

--- a/src/modules/bands/resolvers/band.resolver.ts
+++ b/src/modules/bands/resolvers/band.resolver.ts
@@ -20,5 +20,19 @@ export const bandsResolvers = {
       const genres = await dataSources.Artist.getArtists();
       return genres.filter((g: any) => _source.members.includes(g.id));
     },
+  },
+
+  Mutation: {
+    async createBand(_source: any, _args: any, { dataSources, token }: any) {
+      return dataSources.Band.createBand(_args, token);
+    },
+
+    async deleteBand(_source: any, { id }: any, { dataSources, token }: any) {
+      return dataSources.Band.deleteBand(id, token);
+    },
+
+    async updateBand(_source: any, { id, ..._args }: any, { dataSources, token }: any) {
+      return dataSources.Band.updateBand(id, _args, token);
+    }
   }
 };

--- a/src/modules/bands/resolvers/band.resolver.ts
+++ b/src/modules/bands/resolvers/band.resolver.ts
@@ -1,0 +1,12 @@
+export const bandsResolvers = {
+  Query: {
+    bands:
+      async (_source: any, _args: any, { dataSources }: any) => {
+        const { offset, limit } = _args;
+        return dataSources.Band.getBands(limit, offset, dataSources.Genre);
+      },
+    band(_source: any, { id }: { id: string; }, { dataSources }: any) {
+      return dataSources.Band.getBand(id);
+    }
+  }
+};

--- a/src/modules/bands/resolvers/band.resolver.ts
+++ b/src/modules/bands/resolvers/band.resolver.ts
@@ -1,12 +1,24 @@
 export const bandsResolvers = {
   Query: {
-    bands:
-      async (_source: any, _args: any, { dataSources }: any) => {
-        const { offset, limit } = _args;
-        return dataSources.Band.getBands(limit, offset, dataSources.Genre);
-      },
-    band(_source: any, { id }: { id: string; }, { dataSources }: any) {
+    async bands(_source: any, _args: any, { dataSources }: any) {
+      const { offset, limit } = _args;
+      return dataSources.Band.getBands(limit, offset, dataSources.Genre);
+    },
+
+    async band(_source: any, { id }: { id: string; }, { dataSources }: any) {
       return dataSources.Band.getBand(id);
     }
+  },
+
+  Band: {
+    async genres(_source: any, _args: any, { dataSources }: any) {
+      const genres = await dataSources.Genre.getGenres();
+      return genres.filter((g: any) => _source.genresIds.includes(g.id));
+    },
+
+    async members(_source: any, _args: any, { dataSources }: any) {
+      const genres = await dataSources.Artist.getArtists();
+      return genres.filter((g: any) => _source.members.includes(g.id));
+    },
   }
 };

--- a/src/modules/bands/schemas/band.schema.ts
+++ b/src/modules/bands/schemas/band.schema.ts
@@ -17,18 +17,18 @@ type Mutation {
     createBand(
         name: String
         origin: String
-        members: [String]
+        membersId: [String]
         website: String
-        genres: [String]): Band
+        genresIds: [String]): Band
 
     deleteBand(id: ID!): Result
     updateBand(
         id: ID!
         name: String
         origin: String
-        members: [String]
+        membersId: [String]
         website: String
-        genres: [String]): Band
+        genresIds: [String]): Band
 }
 `;
 

--- a/src/modules/bands/schemas/band.schema.ts
+++ b/src/modules/bands/schemas/band.schema.ts
@@ -1,0 +1,23 @@
+export const bandType = `
+type Band {
+    id: ID!
+    name: String
+    origin: String
+    members: [Member]
+    website: String
+    genres: [Genre]
+}
+
+type Query {
+    band(id: ID!): Band
+    bands(limit: Int, offset: Int): [Band]
+}`;
+
+export const memberType = `type Member {
+    id: ID!
+    firstName: String
+    secondName: String
+    middleName: String
+    instrument: String
+    years: [String]
+}`;

--- a/src/modules/bands/schemas/band.schema.ts
+++ b/src/modules/bands/schemas/band.schema.ts
@@ -11,7 +11,26 @@ type Band {
 type Query {
     band(id: ID!): Band
     bands(limit: Int, offset: Int): [Band]
-}`;
+}
+
+type Mutation {
+    createBand(
+        name: String
+        origin: String
+        members: [String]
+        website: String
+        genres: [String]): Band
+
+    deleteBand(id: ID!): Result
+    updateBand(
+        id: ID!
+        name: String
+        origin: String
+        members: [String]
+        website: String
+        genres: [String]): Band
+}
+`;
 
 export const memberType = `type Member {
     id: ID!

--- a/src/modules/bands/services/band.service.ts
+++ b/src/modules/bands/services/band.service.ts
@@ -1,0 +1,30 @@
+import { RESTDataSource } from 'apollo-datasource-rest';
+import { GenreService } from '../../genres/services/genre.service';
+
+export class BandService extends RESTDataSource {
+  constructor() {
+    super();
+    this.baseURL = process.env.BANDS_BASE_URL;
+  }
+
+  async getBands(limit: number = 20, offset: number = 0, genreService: GenreService) {
+    const resp = await this.get(`bands?limit=${limit}&offset=${offset}`);
+    resp.items.forEach((i: any) => i.id = i._id);
+    for (const item of resp.items) {
+      item.genres = await this.getGenres(item.genresIds, genreService);
+    }
+    return resp.items;
+  }
+  async getBand(id: string) {
+    const item = await this.get(`bands/${id}`);
+    item.id = item._id;
+    return item;
+  }
+
+  async getGenres(genresIds: [string], genreService: GenreService) {
+    const genres = await genreService.getGenres();
+    const neededGenres = genres.filter((g: any) => genresIds.includes(g._id));
+    return neededGenres;
+  }
+
+};

--- a/src/modules/bands/services/band.service.ts
+++ b/src/modules/bands/services/band.service.ts
@@ -18,4 +18,36 @@ export class BandService extends RESTDataSource {
     item.id = item._id;
     return item;
   }
+
+  async createBand(data: any, token: string) {
+    const band = await this.post(`bands`, data,
+      {
+        headers: {
+          Authorization: `${token}`
+        }
+      });
+    band.id = band._id;
+    return band;
+  }
+
+  async deleteBand(id: string, token: string) {
+    const result = await this.delete(`bands/${id}`, undefined,
+      {
+        headers: {
+          Authorization: `${token}`
+        }
+      });
+    return result;
+  }
+
+  async updateBand(id: string, data: any, token: string) {
+    const band = await this.put(`bands/${id}`, data,
+      {
+        headers: {
+          Authorization: `${token}`
+        }
+      });
+    band.id = band._id;
+    return band;
+  }
 };

--- a/src/modules/bands/services/band.service.ts
+++ b/src/modules/bands/services/band.service.ts
@@ -10,21 +10,12 @@ export class BandService extends RESTDataSource {
   async getBands(limit: number = 20, offset: number = 0, genreService: GenreService) {
     const resp = await this.get(`bands?limit=${limit}&offset=${offset}`);
     resp.items.forEach((i: any) => i.id = i._id);
-    for (const item of resp.items) {
-      item.genres = await this.getGenres(item.genresIds, genreService);
-    }
     return resp.items;
   }
+
   async getBand(id: string) {
     const item = await this.get(`bands/${id}`);
     item.id = item._id;
     return item;
   }
-
-  async getGenres(genresIds: [string], genreService: GenreService) {
-    const genres = await genreService.getGenres();
-    const neededGenres = genres.filter((g: any) => genresIds.includes(g._id));
-    return neededGenres;
-  }
-
 };

--- a/src/modules/genres/resolvers/genre.resolver.ts
+++ b/src/modules/genres/resolvers/genre.resolver.ts
@@ -8,5 +8,19 @@ export const genresResolvers = {
     async genre(_source: any, { id }: { id: string; }, { dataSources }: any) {
       return dataSources.Genre.getGenre(id);
     }
+  },
+
+  Mutation: {
+    async createGenre(_source: any, _args: any, { dataSources, token }: any) {
+      return dataSources.Genre.createGenre(_args, token);
+    },
+
+    async deleteGenre(_source: any, { id }: any, { dataSources, token }: any) {
+      return dataSources.Genre.deleteGenre(id, token);
+    },
+
+    async updateGenre(_source: any, { id, ..._args }: any, { dataSources, token }: any) {
+      return dataSources.Genre.updateGenre(id, _args, token);
+    }
   }
 };

--- a/src/modules/genres/resolvers/genre.resolver.ts
+++ b/src/modules/genres/resolvers/genre.resolver.ts
@@ -1,4 +1,4 @@
-export const resolvers = {
+export const genresResolvers = {
   Query: {
     genres:
       async (_source: any, _args: any, { dataSources }: any) => {

--- a/src/modules/genres/resolvers/genre.resolver.ts
+++ b/src/modules/genres/resolvers/genre.resolver.ts
@@ -1,0 +1,12 @@
+export const resolvers = {
+  Query: {
+    genres:
+      async (_source: any, _args: any, { dataSources }: any) => {
+        const { offset, limit } = _args;
+        return dataSources.Genre.getGenres(limit, offset);
+      },
+    genre(_source: any, { id }: { id: string; }, { dataSources }: any) {
+      return dataSources.Genre.getGenre(id);
+    }
+  }
+};

--- a/src/modules/genres/resolvers/genre.resolver.ts
+++ b/src/modules/genres/resolvers/genre.resolver.ts
@@ -1,11 +1,11 @@
 export const genresResolvers = {
   Query: {
-    genres:
-      async (_source: any, _args: any, { dataSources }: any) => {
-        const { offset, limit } = _args;
-        return dataSources.Genre.getGenres(limit, offset);
-      },
-    genre(_source: any, { id }: { id: string; }, { dataSources }: any) {
+    async genres(_source: any, _args: any, { dataSources }: any) {
+      const { offset, limit } = _args;
+      return dataSources.Genre.getGenres(limit, offset);
+    },
+
+    async genre(_source: any, { id }: { id: string; }, { dataSources }: any) {
       return dataSources.Genre.getGenre(id);
     }
   }

--- a/src/modules/genres/schemas/genre.schema.ts
+++ b/src/modules/genres/schemas/genre.schema.ts
@@ -1,0 +1,13 @@
+export const genreType = `
+type Genre {
+    id: ID!
+    name: String
+    description: String
+    country: String
+    year: Int
+}
+
+type Query {
+  genre(id: ID!): Genre
+  genres(limit: Int, offset: Int): [Genre]
+}`;

--- a/src/modules/genres/schemas/genre.schema.ts
+++ b/src/modules/genres/schemas/genre.schema.ts
@@ -10,4 +10,21 @@ type Genre {
 type Query {
   genre(id: ID!): Genre
   genres(limit: Int, offset: Int): [Genre]
-}`;
+}
+
+type Mutation {
+  createGenre(
+    name: String
+    description: String
+    country: String
+    year: Int): Genre
+
+  deleteGenre(id: ID!): Result
+  updateGenre(
+      id: ID!
+      name: String
+      description: String
+      country: String
+      year: Int): Genre
+}
+`;

--- a/src/modules/genres/services/genre.service.ts
+++ b/src/modules/genres/services/genre.service.ts
@@ -1,0 +1,19 @@
+import { RESTDataSource } from 'apollo-datasource-rest';
+
+export class GenreService extends RESTDataSource {
+  constructor() {
+    super();
+    this.baseURL = process.env.GENRES_BASE_URL;
+  }
+
+  async getGenres(limit: number = 20, offset: number = 0) {
+    const resp = await this.get(`genres?limit=${limit}&offset=${offset}`);
+    resp.items.forEach((i: any) => i.id = i._id);
+    return resp.items;
+  }
+  async getGenre(id: string) {
+    const item = await this.get(`genres/${id}`);
+    item.id = item._id;
+    return item;
+  }
+};

--- a/src/modules/genres/services/genre.service.ts
+++ b/src/modules/genres/services/genre.service.ts
@@ -17,4 +17,36 @@ export class GenreService extends RESTDataSource {
     item.id = item._id;
     return item;
   }
+
+  async createGenre(data: any, token: string) {
+    const genre = await this.post(`genres`, data,
+      {
+        headers: {
+          Authorization: `${token}`
+        }
+      });
+    genre.id = genre._id;
+    return genre;
+  }
+
+  async deleteGenre(id: string, token: string) {
+    const result = await this.delete(`genres/${id}`, undefined,
+      {
+        headers: {
+          Authorization: `${token}`
+        }
+      });
+    return result;
+  }
+
+  async updateGenre(id: string, data: any, token: string) {
+    const genre = await this.put(`genres/${id}`, data,
+      {
+        headers: {
+          Authorization: `${token}`
+        }
+      });
+    genre.id = genre._id;
+    return genre;
+  }
 };

--- a/src/modules/genres/services/genre.service.ts
+++ b/src/modules/genres/services/genre.service.ts
@@ -11,6 +11,7 @@ export class GenreService extends RESTDataSource {
     resp.items.forEach((i: any) => i.id = i._id);
     return resp.items;
   }
+
   async getGenre(id: string) {
     const item = await this.get(`genres/${id}`);
     item.id = item._id;

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -1,0 +1,3 @@
+export * from './genres/schemas/genre.schema';
+export * from './genres/resolvers/genre.resolver';
+export * from './genres/services/genre.service';

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -9,3 +9,11 @@ export * from './artists/services/artist.service';
 export * from './bands/schemas/band.schema';
 export * from './bands/resolvers/band.resolver';
 export * from './bands/services/band.service';
+
+export * from './albums/schemas/album.schema';
+export * from './albums/resolvers/album.resolver';
+export * from './albums/services/album.service';
+
+export * from './tracks/schemas/track.schema';
+export * from './tracks/resolvers/track.resolver';
+export * from './tracks/services/track.service';

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -7,3 +7,5 @@ export * from './artists/resolvers/artist.resolver';
 export * from './artists/services/artist.service';
 
 export * from './bands/schemas/band.schema';
+export * from './bands/resolvers/band.resolver';
+export * from './bands/services/band.service';

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -1,3 +1,9 @@
 export * from './genres/schemas/genre.schema';
 export * from './genres/resolvers/genre.resolver';
 export * from './genres/services/genre.service';
+
+export * from './artists/schemas/artist.schema';
+export * from './artists/resolvers/artist.resolver';
+export * from './artists/services/artist.service';
+
+export * from './bands/schemas/band.schema';

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -17,3 +17,7 @@ export * from './albums/services/album.service';
 export * from './tracks/schemas/track.schema';
 export * from './tracks/resolvers/track.resolver';
 export * from './tracks/services/track.service';
+
+export * from './users/schemas/user.schema';
+export * from './users/resolvers/user.resolver';
+export * from './users/services/user.service';

--- a/src/modules/tracks/resolvers/track.resolver.ts
+++ b/src/modules/tracks/resolvers/track.resolver.ts
@@ -29,5 +29,19 @@ export const tracksResolvers = {
       const genres = await dataSources.Genre.getGenres();
       return genres.filter((g: any) => _source.genresIds.includes(g.id));
     }
+  },
+
+  Mutation: {
+    async createTrack(_source: any, _args: any, { dataSources, token }: any) {
+      return dataSources.Track.createTrack(_args, token);
+    },
+
+    async deleteTrack(_source: any, { id }: any, { dataSources, token }: any) {
+      return dataSources.Track.deleteTrack(id, token);
+    },
+
+    async updateTrack(_source: any, { id, ..._args }: any, { dataSources, token }: any) {
+      return dataSources.Track.updateTrack(id, _args, token);
+    }
   }
 };

--- a/src/modules/tracks/resolvers/track.resolver.ts
+++ b/src/modules/tracks/resolvers/track.resolver.ts
@@ -1,0 +1,33 @@
+export const tracksResolvers = {
+  Query: {
+    tracks:
+      async (_source: any, _args: any, { dataSources }: any) => {
+        const { offset, limit } = _args;
+        return dataSources.Track.getTracks(limit, offset);
+      },
+
+    track(_source: any, { id }: { id: string; }, { dataSources }: any) {
+      return dataSources.Track.getTrack(id);
+    }
+  },
+  Track: {
+    async artists(_source: any, _args: any, { dataSources }: any) {
+      const artists = await dataSources.Artist.getArtists();
+      return artists.filter((a: any) => _source.artistsIds.includes(a.id));
+    },
+
+    async bands(_source: any, _args: any, { dataSources }: any) {
+      const bands = await dataSources.Band.getBands();
+      return bands.filter((b: any) => _source.bandsIds.includes(b.id));
+    },
+
+    async album(_source: any, _args: any, { dataSources }: any) {
+      return await dataSources.Album.getAlbum(_source.albumId);
+    },
+
+    async genres(_source: any, _args: any, { dataSources }: any) {
+      const genres = await dataSources.Genre.getGenres();
+      return genres.filter((g: any) => _source.genresIds.includes(g.id));
+    }
+  }
+};

--- a/src/modules/tracks/schemas/track.schema.ts
+++ b/src/modules/tracks/schemas/track.schema.ts
@@ -1,0 +1,16 @@
+export const trackType = `
+type Track {
+    id: ID!
+    title: String!
+    album: Album
+    artists: [Artist]
+    bands: [Band]
+    duration: Int
+    released: Int
+    genres: [Genre]
+}
+
+type Query {
+    track(id: ID!): Track
+    tracks(limit: Int, offset: Int): [Track]
+}`;

--- a/src/modules/tracks/schemas/track.schema.ts
+++ b/src/modules/tracks/schemas/track.schema.ts
@@ -13,4 +13,26 @@ type Track {
 type Query {
     track(id: ID!): Track
     tracks(limit: Int, offset: Int): [Track]
+}
+
+type Mutation {
+    createTrack(
+        title: String!
+        albumId: String
+        artists: [String]
+        bands: [String]
+        duration: Int
+        released: Int
+        genresIds: [String]): Track
+
+    deleteTrack(id: ID!): Result
+    updateTrack(
+        id: ID!
+        title: String
+        album: String
+        artists: [String]
+        bands: [String]
+        duration: Int
+        released: Int
+        genresIds: [String]): Track
 }`;

--- a/src/modules/tracks/schemas/track.schema.ts
+++ b/src/modules/tracks/schemas/track.schema.ts
@@ -19,8 +19,8 @@ type Mutation {
     createTrack(
         title: String!
         albumId: String
-        artists: [String]
-        bands: [String]
+        artistsIds: [String]
+        bandsIds: [String]
         duration: Int
         released: Int
         genresIds: [String]): Track
@@ -30,8 +30,8 @@ type Mutation {
         id: ID!
         title: String
         album: String
-        artists: [String]
-        bands: [String]
+        artistsIds: [String]
+        bandsIds: [String]
         duration: Int
         released: Int
         genresIds: [String]): Track

--- a/src/modules/tracks/services/track.service.ts
+++ b/src/modules/tracks/services/track.service.ts
@@ -1,0 +1,19 @@
+import { RESTDataSource } from 'apollo-datasource-rest';
+
+export class TrackService extends RESTDataSource {
+  constructor() {
+    super();
+    this.baseURL = process.env.TRACKS_BASE_URL;
+  }
+
+  async getTracks(limit: number = 20, offset: number = 0) {
+    const resp = await this.get(`tracks?limit=${limit}&offset=${offset}`);
+    resp.items.forEach((i: any) => i.id = i._id);
+    return resp.items;
+  }
+  async getTrack(id: string) {
+    const item = await this.get(`tracks/${id}`);
+    item.id = item._id;
+    return item;
+  }
+};

--- a/src/modules/tracks/services/track.service.ts
+++ b/src/modules/tracks/services/track.service.ts
@@ -11,9 +11,42 @@ export class TrackService extends RESTDataSource {
     resp.items.forEach((i: any) => i.id = i._id);
     return resp.items;
   }
+
   async getTrack(id: string) {
     const item = await this.get(`tracks/${id}`);
     item.id = item._id;
     return item;
+  }
+
+  async createTrack(data: any, token: string) {
+    const tracks = await this.post(`tracks`, data,
+      {
+        headers: {
+          Authorization: `${token}`
+        }
+      });
+    tracks.id = tracks._id;
+    return tracks;
+  }
+
+  async deleteTrack(id: string, token: string) {
+    const result = await this.delete(`tracks/${id}`, undefined,
+      {
+        headers: {
+          Authorization: `${token}`
+        }
+      });
+    return result;
+  }
+
+  async updateTrack(id: string, data: any, token: string) {
+    const tracks = await this.put(`tracks/${id}`, data,
+      {
+        headers: {
+          Authorization: `${token}`
+        }
+      });
+    tracks.id = tracks._id;
+    return tracks;
   }
 };

--- a/src/modules/users/resolvers/user.resolver.ts
+++ b/src/modules/users/resolvers/user.resolver.ts
@@ -8,4 +8,10 @@ export const usersResolvers = {
       return dataSources.User.login(email, password);
     }
   },
+
+  Mutation: {
+    async register(_source: any, _args: any, { dataSources }: any) {
+      return dataSources.User.register(_args);
+    },
+  }
 };

--- a/src/modules/users/resolvers/user.resolver.ts
+++ b/src/modules/users/resolvers/user.resolver.ts
@@ -1,7 +1,11 @@
 export const usersResolvers = {
   Query: {
-    user(_source: any, { id }: { id: string; }, { dataSources }: any) {
+    async user(_source: any, { id }: { id: string; }, { dataSources }: any) {
       return dataSources.User.getUser(id);
+    },
+
+    async jwt(_source: any, { email, password }: { email: string; password: string; }, { dataSources }: any) {
+      return dataSources.User.login(email, password);
     }
   },
 };

--- a/src/modules/users/resolvers/user.resolver.ts
+++ b/src/modules/users/resolvers/user.resolver.ts
@@ -1,0 +1,7 @@
+export const usersResolvers = {
+  Query: {
+    user(_source: any, { id }: { id: string; }, { dataSources }: any) {
+      return dataSources.User.getUser(id);
+    }
+  },
+};

--- a/src/modules/users/schemas/user.schema.ts
+++ b/src/modules/users/schemas/user.schema.ts
@@ -9,5 +9,6 @@ export const userType = `
 
 type Query {
   user(id: ID!): User
+  jwt(email: String!, password: String!): String
 }
 `;

--- a/src/modules/users/schemas/user.schema.ts
+++ b/src/modules/users/schemas/user.schema.ts
@@ -1,0 +1,13 @@
+export const userType = `
+  type User {
+  id: ID!
+  firstName: String
+  secondName: String
+  password: String
+  email: String!
+}
+
+type Query {
+  user(id: ID!): User
+}
+`;

--- a/src/modules/users/schemas/user.schema.ts
+++ b/src/modules/users/schemas/user.schema.ts
@@ -2,7 +2,7 @@ export const userType = `
   type User {
   id: ID!
   firstName: String
-  secondName: String
+  lastName: String
   password: String
   email: String!
 }
@@ -10,5 +10,14 @@ export const userType = `
 type Query {
   user(id: ID!): User
   jwt(email: String!, password: String!): String
+}
+
+type Mutation {
+  register(
+    firstName: String
+    lastName: String
+    password: String
+    email: String!
+      ): User
 }
 `;

--- a/src/modules/users/services/user.service.ts
+++ b/src/modules/users/services/user.service.ts
@@ -11,4 +11,9 @@ export class UserService extends RESTDataSource {
     item.id = item._id;
     return item;
   }
+
+  async login(email: string, password: string) {
+    const item = await this.post(`users/login`, { email, password });
+    return item.jwt;
+  }
 };

--- a/src/modules/users/services/user.service.ts
+++ b/src/modules/users/services/user.service.ts
@@ -1,0 +1,14 @@
+import { RESTDataSource } from 'apollo-datasource-rest';
+
+export class UserService extends RESTDataSource {
+  constructor() {
+    super();
+    this.baseURL = process.env.USERS_BASE_URL;
+  }
+
+  async getUser(id: string) {
+    const item = await this.get(`users/${id}`);
+    item.id = item._id;
+    return item;
+  }
+};

--- a/src/modules/users/services/user.service.ts
+++ b/src/modules/users/services/user.service.ts
@@ -16,4 +16,10 @@ export class UserService extends RESTDataSource {
     const item = await this.post(`users/login`, { email, password });
     return item.jwt;
   }
+
+  async register(data: any) {
+    const user = await this.post(`users/register`, data);
+    user.id = user._id;
+    return user;
+  }
 };


### PR DESCRIPTION
Task: https://github.com/AlreadyBored/nodejs-assignments/blob/main/assignments/graphql-service/score.md

Deadline: 10.07.2022 23:59

Score: 420 / 490

## Basic Scope

- [✔ ] **+20** The repository with the application contains a `Readme.md` file containing detailed instructions for installing, running and using the application
- [ ✔] **+20** The application code that worked with `Users` instance divided into modules according to to its purpose and Nest.js architecture conventions (work with request and response in controller, business logic in service, etc.)
- [✔ ] **+20** The application code that worked with `Tracks` instance instance divided into modules according to to its purpose and Nest.js architecture conventions (work with request and response in controller, business logic in service, etc.)
- [ ✔] **+20** The application code that worked with `Albums` instance instance divided into modules according to to its purpose and Nest.js architecture conventions (work with request and response in controller, business logic in service, etc.)
- [ ✔] **+20** The application code that worked with `Artists` instance instance divided into modules according to to its purpose and Nest.js architecture conventions (work with request and response in controller, business logic in service, etc.)
- [❌] **+20** The application code that worked with `Favorites` instance instance divided into modules according to to its purpose and Nest.js architecture conventions (work with request and response in controller, business logic in service, etc.)
- [ ✔] **+20** The application code that worked with `Genres` instance instance divided into modules according to to its purpose and Nest.js architecture conventions (work with request and response in controller, business logic in service, etc.)
- [ ✔] **+20** The application code that worked with `Bands` instance instance divided into modules according to to its purpose and Nest.js architecture conventions (work with request and response in controller, business logic in service, etc.)

## **+10** Every implemented query/mutation:

### Queries:
  - [✔ ] **+10** artist
  - [ ✔] **+10** artists
  - [✔ ] **+10** genre
  - [ ✔] **+10** genres
  - [ ✔] **+10** track
  - [✔ ] **+10** tracks
  - [✔ ] **+10** band
  - [ ✔] **+10** bands
  - [ ✔] **+10** album
  - [ ✔] **+10** albums
  - [✔ ] **+10** jwt 
  - [ ✔] **+10** user
  - [ ❌] **+10** favourites (available only for logged in user)

### Mutations:

- Artists
  - [✔ ] **+10** createArtist
  - [✔ ] **+10** deleteArtist
  - [✔ ] **+10** updateArtist
- Genres
  - [ ✔] **+10** createGenre
  - [ ✔] **+10** deleteGenre
  - [✔ ] **+10** updateGenre
- Bands
  - [✔ ] **+10** createBand
  - [✔ ] **+10** deleteBand
  - [✔ ] **+10** updateBand
- Tracks
  - [ ✔] **+10** createTrack
  - [✔ ] **+10** deleteTrack
  - [✔ ] **+10** updateTrack
- Albums
  - [✔ ] **+10** createAlbum
  - [✔ ] **+10** deleteAlbum
  - [✔ ] **+10** updateAlbum
- Users
  - [✔ ] **+10** register
- Favourites
  - [❌ ] **+10** addTrackToFavourites
  - [❌] **+10** addBandToFavourites
  - [❌ ] **+10** addArtistToFavourites
  - [ ❌] **+10** addGenreToFavourites

## Forfeits

- **-30% of max task score** Commits after deadline (except commits that affect only Readme.md, .gitignore, etc.)
- **-20** No separate development branch
- **-20** No Pull Request
- **-10** Pull Request description is incorrect